### PR TITLE
:truck: TopicEntry 엔티티 패키지 이동 #26

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/entity/TopicEntry.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/entity/TopicEntry.java
@@ -1,7 +1,6 @@
-package com.buck.vsplay.domain.entry.entity;
+package com.buck.vsplay.domain.vstopic.entity;
 
 
-import com.buck.vsplay.domain.vstopic.entity.VsTopic;
 import com.buck.vsplay.global.entity.Timestamp;
 import jakarta.persistence.*;
 import lombok.Getter;


### PR DESCRIPTION
### 📌 이슈
> #26

### ✅ 작업내용
- 기존에는 TopicEntry 를 별도의 패키지로 구성하여, 비즈니스 로직을 분리하려고 했음
- 하지만 다시 고민해보니, 비지니스 로직 관점에서 VsTopic 엔트리와 강하게 결합이 되어있어 분리 할 경우 불필요한 주입과 참조가 발생할 것으로 예상
- 설계지향점을 고려해보았을 때 동일한 패키지에 두는 것이 불필요한 분리와 참조를 피할 수 있을 것으로 판단하여 분리
