### PR TITLE
:bug: 토큰 발급자 검증 로직 오탈자 수정 #48

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/global/security/jwt/JwtService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/global/security/jwt/JwtService.java
@@ -93,7 +93,7 @@ public class JwtService{
                     .getBody();
 
             // 발급자 검증
-            if(issuer.equals(claims.getIssuer())){
+            if(!issuer.equals(claims.getIssuer())){
                 throw new JwtException(JwtExceptionCode.INVALID_ISSUER);
             }
             return true;


### PR DESCRIPTION
### 📌 이슈
> #48

### ✅ 작업내용
- 토큰 검증 메서드 내 발급자 검사 로직이 참일 때 잘못처리되고 있어서 수정
