### PR TITLE
:recycle: 유저 정보 확인 불가 시 반환되는 Exception 변경  #54

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/global/security/service/impl/AuthUserService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/global/security/service/impl/AuthUserService.java
@@ -1,6 +1,8 @@
 package com.buck.vsplay.global.security.service.impl;
 
 import com.buck.vsplay.domain.member.entity.Member;
+import com.buck.vsplay.domain.member.exception.MemberException;
+import com.buck.vsplay.domain.member.exception.MemberExceptionCode;
 import com.buck.vsplay.domain.member.repository.MemberRepository;
 import com.buck.vsplay.global.security.service.IAuthUserService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,6 @@ public class AuthUserService implements IAuthUserService {
         }
 
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalStateException("Member not found"));
+                .orElseThrow(() -> new MemberException(MemberExceptionCode.MEMBER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
### 📌 이슈
> #54

### ✅ 작업내용
- 유저 정보 확인 불가시 반환 예외를 MemberException 으로 교체
