### PR TITLE
:recycle: VsTopic 엔티티 thumbnail(대표이미지) 항목 추가 #58

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/controller/VsTopicController.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/controller/VsTopicController.java
@@ -8,10 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,7 +18,7 @@ public class VsTopicController {
 
     @PostMapping
     public ResponseEntity<SingleResponseDto<Integer>> createTopic(
-            @RequestBody @Valid VsTopicDto.VsTopicCreateRequest vsTopicDCreateVsTopicRequest) {
+            @ModelAttribute @Valid VsTopicDto.VsTopicCreateRequest vsTopicDCreateVsTopicRequest) {
 
         vsTopicService.createVsTopic(vsTopicDCreateVsTopicRequest);
         return new ResponseEntity<>(new SingleResponseDto<>(HttpStatus.OK.value()),HttpStatus.OK );

--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/dto/VsTopicDto.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/dto/VsTopicDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Data
@@ -28,6 +29,7 @@ public class VsTopicDto {
         @NotNull(message = "대결 주제는 필수 입력 항목입니다.")
         private String subject;
         private String description;
+        private MultipartFile thumbnail;
     }
 
 }

--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/entity/VsTopic.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/entity/VsTopic.java
@@ -34,6 +34,9 @@ public class VsTopic extends Timestamp{
     @Column(name = "description", length = 200)
     private String description;
 
+    @Column(name = "thumbnail", length = 200)
+    private String thumbnail;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "visibility")
     @ColumnDefault("'PUBLIC'")

--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/mapper/VsTopicMapper.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/mapper/VsTopicMapper.java
@@ -4,12 +4,14 @@ package com.buck.vsplay.domain.vstopic.mapper;
 import com.buck.vsplay.domain.vstopic.dto.VsTopicDto;
 import com.buck.vsplay.domain.vstopic.entity.VsTopic;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring")
 public interface VsTopicMapper {
     VsTopicMapper INSTANCE = Mappers.getMapper(VsTopicMapper.class);
     VsTopic toEntity(VsTopicDto.VsTopic vsTopic);
+    @Mapping(target = "thumbnail", ignore = true)
     VsTopic toEntity(VsTopicDto.VsTopicCreateRequest vsTopicCreateRequest);
     VsTopicDto.VsTopic toDto(VsTopic vsTopic);
 }


### PR DESCRIPTION
### 📌 이슈
> #58 

### ✅ 작업내용
- VsTopic 엔티티 내 thumbnail 항목 추가
- 주제생성요청 dto 에 entity 와 매핑 하게 될  thumbnail 항목 추가 
- 변경된 주제생성요청 dto 에 맞추어 주제생성요청 컨트롤러 요청 타입 변경

