### PR TITLE
:recycle: 활성화 여부 컬럼 is_active 추가 #73

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/statistics/entity/TournamentStatistics.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/statistics/entity/TournamentStatistics.java
@@ -34,4 +34,8 @@ public class TournamentStatistics extends Timestamp {
     @Comment("진행 횟수")
     private Integer stageMatches;
 
+    @Column(name = "is_active", nullable = false)
+    @Comment("활성화 여부")
+    private boolean active;
+
 }


### PR DESCRIPTION
### 📌 이슈
> #73

### ✅ 작업내용
- 기획이 변경 되었음
   - 기존에는 주제에서 진행가능한 토너먼트 값을 제작자가 사전 설정하는 방식
   - 이 방식은 제작자의 편의성을 헤칠 수 있다고 판단
   - 따라서
      - 진행가능한 토너먼트 조회는 실시간 엔트리 등록 상태를 확인하여 조회
      - 현재 사용자가 실시간으로 진행 가능한 토너먼트를 구분하는 용도로, 토너먼트 분석은 active 플래그를 추가 
