### PR TITLE
:recycle: EntryMatch 엔티티 수정 #76

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/entity/EntryMatch.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/entity/EntryMatch.java
@@ -13,22 +13,45 @@ import org.hibernate.annotations.Comment;
 @Setter
 @Table(name = "ENTRY_MATCH")
 @SequenceGenerator(name = "ENTRY_MATCH_SEQ_GENERATOR", sequenceName = "ENTRY_MATCH_SEQ")
-@Comment("엔트리 간 대결 기록, 엔트리 1:1 이므로 하나의 엔트리 대결당 2개의 entry_match 가 기록됨")
+@Comment("엔트리 간 대결 기록")
 public class EntryMatch extends Timestamp {
     @Id
     @Column(name = "match_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "entry_id")
-    private TopicEntry topicEntry;
+    @JoinColumn(name = "topic_record_id", nullable = false)
+    private TopicPlayRecord topicPlayRecord;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "opponent_entry_id")
-    @Comment("상대 엔트리")
-    private TopicEntry opponentEntry;
+    @JoinColumn(name = "entry_a", nullable = false)
+    private TopicEntry entryA;
 
-    @Column(name = "is_winner")
-    private boolean winner = false;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "entry_b", nullable = false)
+    private TopicEntry entryB;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "winner_entry", nullable = false)
+    @Comment("승리한 엔트리")
+    private TopicEntry winnerEntry;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "loser_entry", nullable = false)
+    @Comment("패배한 엔트리")
+    private TopicEntry loserEntry;
+
+    @Column(name = "tournament_round", nullable = false)
+    @Comment("토너먼트")
+    private Integer tournamentRound;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    @Comment("진행상태")
+    private EntryMatch.Status status = EntryMatch.Status.IN_PROGRESS;
+
+    public enum Status{
+        IN_PROGRESS,
+        COMPLETED
+    }
 }


### PR DESCRIPTION
### 📌 이슈
> #76

### ✅ 작업내용
- ENTRY_MATCH 를 통계의 목적만이 아닌 TOPIC_PLAY_RECORD 와 매핑하여 진행기록저장 테이블로 사용하도록 조정
