### PR TITLE
:sparkles: EntryVersusStatistics 엔티티 추가 #78

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/statistics/entity/EntryVersusStatistics.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/statistics/entity/EntryVersusStatistics.java
@@ -1,0 +1,44 @@
+package com.buck.vsplay.domain.statistics.entity;
+
+import com.buck.vsplay.domain.vstopic.entity.TopicEntry;
+import com.buck.vsplay.global.entity.Timestamp;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "ENTRY_VERSUS_STATISTICS")
+@Getter
+@Setter
+@SequenceGenerator(name = "VERSUS_STATS_SEQ_GENERATOR" , sequenceName = "VERSUS_STATS_SEQ")
+@NoArgsConstructor
+@Comment("엔트리 상성 통계")
+public class EntryVersusStatistics extends Timestamp {
+
+    @Id
+    @Column(name = "versus_stats_id")
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "entry_id", nullable = false)
+    private TopicEntry topicEntry;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "opponent_entry_id", nullable = false)
+    private TopicEntry opponentEntry;
+
+    @Column(name = "total_matches")
+    private Integer totalMatches;
+
+    @Column(name = "wins")
+    private Integer wins;
+
+    @Column(name = "losses")
+    private Integer losses;
+
+    @Column(name = "win_rate")
+    private Double winRate;
+
+}


### PR DESCRIPTION
### 📌 이슈
> #78

### ✅ 작업내용
- EntryVersusStatistics 엔티티 추가
- 기존의 ENTRY_MATCH 와 ENTRY_STATISTICS 로는 "특정 엔트리에 대한 승/패 및 상성 통계" 처리가 어렵다고 판단
   - 엔트리간 상성 통계를 위한 테이블 신규 생성 및 엔티티 매핑
   - 비즈니스 로직에서는 실시간 갱신 & 배치 를 적용하여 갱신 예정
