### PR TITLE
S3Util 업로드 경로 생성 메서드 추가 #83

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/global/util/aws/s3/S3Util.java
+++ b/vsplay/src/main/java/com/buck/vsplay/global/util/aws/s3/S3Util.java
@@ -84,4 +84,8 @@ public class S3Util {
             throw new S3Exception(S3ExceptionCode.FILE_EMPTY_OR_INVALID);
         }
     }
+
+    public String buildS3Path(String ... parts){
+        return String.join("/", parts);
+    }
 }


### PR DESCRIPTION
### 📌 이슈
> #83

### ✅ 작업내용
- 업로드 Util  호출부에서 불필요하게 hard 코딩된 경로 전달이 예외의 소지가 있으며 반복적인 코드가 작성될 것으로 예상됨
- 따라서 업로드 책임이 부여된 S3 Util 내 범용으로 사용 할 수 있도록 upload build 메서드를 추가
   - String 으로 강제 전달 하도록 정의했기에, 호출부에서 별도의 캐스팅이 필요하다는 번거로움이 있음
   - Util 내에서 다양한 type 의 인스턴스를 허용하기에는, String 으로 캐스팅 시 문제가 될 수 있는 type 의 값이 전달되는 경우 등 Util 내에서도 예외처리 책임이 더해지는데다가, 해당 메서드는 클라이언트에서 제어할 수 있는 항목이 아니기에 처리 과정이 다소 모호하며 S3Util 에 지나치게 큰 책임이 부여됨
   - 종합적으로 고려해보았을 때 간결한 코드작성에서 약간의 아쉬운 부분이 있지만, 해당 방법이 더 안정적이고 용이하다고 판단하여 적용
