### PR TITLE
EntryDto 네이밍 변경 #104

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/dto/EntryDto.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/dto/EntryDto.java
@@ -13,19 +13,19 @@ import java.util.List;
 public class EntryDto {
 
     @Data
-    public static class CreateEntry{
-        private String entryName;
-        private String description;
-        private MultipartFile file;
-    }
-
-    @Data
-    public static class CreatedEntry{
+    public static class Entry{
         private Long entryId;
         private String entryName;
         private String description;
         private MediaType mediaType;
         private String mediaUrl;
+    }
+
+    @Data
+    public static class CreateEntry{
+        private String entryName;
+        private String description;
+        private MultipartFile file;
     }
 
     @Data
@@ -36,6 +36,6 @@ public class EntryDto {
 
     @Data
     public static class CreatedEntryList{
-        List<CreatedEntry> entries;
+        List<Entry> entries;
     }
 }

--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/mapper/TopicEntryMapper.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/mapper/TopicEntryMapper.java
@@ -19,9 +19,9 @@ public interface TopicEntryMapper {
 
     @Mapping(source = "id", target ="entryId")
     @Mapping(target = "mediaUrl" , expression = "java(s3Util.getUploadedObjectUrl(topicEntry.getMediaUrl()))")
-    EntryDto.CreatedEntry toCreatedEntry(TopicEntry topicEntry, @Context S3Util s3Util);
+    EntryDto.Entry toCreatedEntry(TopicEntry topicEntry, @Context S3Util s3Util);
 
-    default List<EntryDto.CreatedEntry> toCreatedEntryDtoList(List<TopicEntry> entries, @Context S3Util s3Util){
+    default List<EntryDto.Entry> toCreatedEntryList(List<TopicEntry> entries, @Context S3Util s3Util){
         return entries.stream()
                 .map(entry -> toCreatedEntry(entry, s3Util))
                 .toList();

--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/EntryService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/EntryService.java
@@ -41,7 +41,7 @@ public class EntryService implements IEntryService {
         topicRepository.findById(topicId).orElseThrow(
                 () -> new VsTopicException(VsTopicExceptionCode.TOPIC_NOT_FOUND));
 
-        createdEntryList.setEntries(topicEntryMapper.toCreatedEntryDtoList(entryRepository.findByTopicId(topicId), s3Util));
+        createdEntryList.setEntries(topicEntryMapper.toCreatedEntryList(entryRepository.findByTopicId(topicId), s3Util));
 
         return createdEntryList;
     }


### PR DESCRIPTION
### 📌 이슈
> #104

### ✅ 작업내용
- 생성관련 단일객체 및 래핑 객체 명칭 변경 
- 조회관련 기본 단일객체 및 래핑 명칭 변경 
