### PR TITLE
대결 진행 기록 엔티티 필드 리팩터링 #132

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/entity/TopicPlayRecord.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/entity/TopicPlayRecord.java
@@ -35,6 +35,10 @@ public class TopicPlayRecord extends Timestamp {
     @Comment("선택된 토너먼트")
     private Integer selectedTournament;
 
+    @Column(name = "current_tournament_stage", nullable = false)
+    @Comment("현재 진행중인 토너먼트")
+    private Integer currentTournamentStage;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
     @Comment("진행상태")


### PR DESCRIPTION
### 📌 이슈
> #132

### ✅ 작업내용
- 기존의 "선택된 토너먼트(tournament)" 컬럼의 name을 selected_tournament로 변경
- "현재 진행중인 토너먼트" current_tournament_stage 를 추가 
