### PR TITLE
대결 주제 진행기록 생성 수정 - 누락된 '현재진행토너먼트 단계' 필드 초기화 추가 #136

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/MatchService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/MatchService.java
@@ -45,6 +45,7 @@ import java.util.*;
             TopicPlayRecord savedTopicPlayRecord = topicPlayRecordRepository.save(TopicPlayRecord.builder()
                     .topic(topic)
                     .selectedTournament(playRecordRequest.getTournamentStage())
+                    .currentTournamentStage(playRecordRequest.getTournamentStage())
                     .status(PlayStatus.IN_PROGRESS)
                     .build());
 


### PR DESCRIPTION
### 📌 이슈
> #136

### ✅ 작업내용
 - 누락된 '현재진행토너먼트 단계' currentTournament 추가 
