### PR TITLE
대결진행기능 구현 5 - 대진표 조회 조건 추가 #141

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/repository/EntryMatchRepository.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/repository/EntryMatchRepository.java
@@ -14,11 +14,12 @@ public interface EntryMatchRepository extends JpaRepository<EntryMatch, Long> {
         SELECT *
         FROM ENTRY_MATCH em
         WHERE em.play_record_id = :playRecordId
+          AND em.tournament_round = :tournamentRound
           AND em.status = 'IN_PROGRESS'
-        ORDER BY em.seq ASC
+        ORDER BY em.seq
         LIMIT 1
     """, nativeQuery = true)
-    EntryMatch findFirstByTopicPlayRecordOrderBySeqAsc(@Param("playRecordId") Long playRecordId);
+    EntryMatch findFirstByTopicPlayRecordOrderBySeqAsc(@Param("playRecordId") Long playRecordId, @Param("tournamentRound") Integer tournamentRound);
 
 
     @Query("SELECT em FROM EntryMatch em JOIN FETCH em.entryA JOIN FETCH em.entryB WHERE em.id = :matchId")

--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/MatchService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/MatchService.java
@@ -68,11 +68,10 @@ import java.util.*;
 
         EntryMatchDto.EntryMatchResponse entryMatchResponse = new EntryMatchDto.EntryMatchResponse();
 
-        if(!topicPlayRecordRepository.existsById(playRecordId)) {
-            throw  new PlayRecordException(PlayRecordExceptionCode.RECORD_NOT_FOUND);
-        }
+        TopicPlayRecord topicPlayRecord = topicPlayRecordRepository.findById(playRecordId).orElseThrow(
+                () -> new PlayRecordException(PlayRecordExceptionCode.RECORD_NOT_FOUND));
 
-        EntryMatch entryMatch = entryMatchRepository.findFirstByTopicPlayRecordOrderBySeqAsc(playRecordId);
+        EntryMatch entryMatch = entryMatchRepository.findFirstByTopicPlayRecordOrderBySeqAsc(topicPlayRecord.getId(), topicPlayRecord.getCurrentTournamentStage());
         EntryMatch entryMatchWithEntries = entryMatchRepository.findWithEntriesById(entryMatch.getId());
 
         entryMatchResponse.setMatchId(entryMatchWithEntries.getId());


### PR DESCRIPTION
### 📌 이슈
> #141

### ✅ 작업내용
- 대진표 조회를 위한 EntryMatch 조회 시,  '토너먼트' 조건 추가
