### PR TITLE
대결진행기능 구현 11 - 진행중인 토너먼트 및 모든 토너먼트 완료 검사 로직 수정 #156

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/MatchService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/MatchService.java
@@ -136,13 +136,13 @@ import java.util.*;
 
         boolean isAllTournamentStageFinish = isAllTournamentStageFinish(topicPlayRecord);
 
-        if(isCurrentTournamentStageFinish(topicPlayRecord)){
-            createNextTournamentStageEntryMatches(topicPlayRecord);
-        }
-
-        if (isAllTournamentStageFinish) {
-            topicPlayRecord.setStatus(PlayStatus.COMPLETED);
-            topicPlayRecordRepository.save(topicPlayRecord);
+        if(isCurrentTournamentStageFinish(topicPlayRecord)){ // 진행중인 토너먼트 종료 여부 확인
+            if ( isAllTournamentStageFinish){ // 현 토너먼트 완료 및 예정되어있는 모든 대진표를 완료 시
+                topicPlayRecord.setStatus(PlayStatus.COMPLETED);
+                topicPlayRecordRepository.save(topicPlayRecord);
+            } else{ // 현 토너먼트 종료 -> 남아있는 다음 토너먼트 대진표 생성
+                createNextTournamentStageEntryMatches(topicPlayRecord);
+            }
         }
 
         return EntryMatchDto.UpdateEntryMatchResultResponse.builder()


### PR DESCRIPTION
### 📌 이슈
> #156

### ✅ 작업내용
- 모든 토너먼트 완료 검사를 현 토너먼트가 모두 완료된 경우에만 실시하도록 수정

### 🖼️ 스크린샷 (선택)
> 이미지 첨부

### 🚩 리뷰 요청 사항
> 리뷰어에게 특별히 확인을 요청할 내용 작성
>
> ex) MemberService 내 비밀번호 변경 관련 메서드 명이 조금 더 직관적이였으면 하는데 좋은 명칭이 있을까요 ?
