### PR TITLE
:recycle: 엔트리 대결 조회 시 이미 완료로 처리된 대결기록은 처리하지 않도록 예외 #157

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/exception/playrecord/PlayRecordExceptionCode.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/exception/playrecord/PlayRecordExceptionCode.java
@@ -12,7 +12,7 @@ public enum PlayRecordExceptionCode implements BaseExceptionCode {
     DUPLICATE_WINNER_LOSER_ENTRY(400, "승리 엔트리와 패배엔트리가 동일합니다.", "PLAY_RECORD_005"),
     MATCH_ALREADY_COMPLETED(400, "이미 완료된 매치입니다.", "PLAY_RECORD_006"),
     INVALID_ENTRY_FOR_MATCH(400, "매치에 포함되지 않는 엔트리입니다.", "PLAY_RECORD_007"),
-
+    PLAY_RECORD_ALREADY_COMPLETED(400, "이미 완료된 대결기록입니다.", "PLAY_RECORD_008"),
     ;
 
 

--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/MatchService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/MatchService.java
@@ -73,6 +73,10 @@ import java.util.*;
         TopicPlayRecord topicPlayRecord = topicPlayRecordRepository.findById(playRecordId).orElseThrow(
                 () -> new PlayRecordException(PlayRecordExceptionCode.RECORD_NOT_FOUND));
 
+        if(topicPlayRecord.getStatus().equals(PlayStatus.COMPLETED)){
+            throw new PlayRecordException(PlayRecordExceptionCode.PLAY_RECORD_ALREADY_COMPLETED);
+        }
+
         EntryMatch entryMatch = entryMatchRepository.findFirstByTopicPlayRecordOrderBySeqAsc(topicPlayRecord.getId(), topicPlayRecord.getCurrentTournamentStage());
         EntryMatch entryMatchWithEntries = entryMatchRepository.findWithEntriesById(entryMatch.getId());
 


### PR DESCRIPTION
### 📌 이슈
> #157

### ✅ 작업내용
- 엔트리 대결 조회 시 이미 완료로 처리된 대결기록은 처리하지 않도록 예외

