### PR TITLE
대결주제 상세정보 조회 API - 주제 정보 누락 #163

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/mapper/VsTopicMapper.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/mapper/VsTopicMapper.java
@@ -20,6 +20,11 @@ public interface VsTopicMapper {
     VsTopicDto.VsTopic toVsTopicDto(VsTopic vsTopic);
     VsTopicDto.Tournament toTournamentDtoFromTournamentEntity(TopicTournament topicTournament);
     List<VsTopicDto.Tournament> toTournamentDtoListFromTournamentEntityList(List<TopicTournament> topicTournaments);
-    VsTopicDto.VsTopicDetailWithTournamentsResponse toVsTopicDetailWithTournaments(VsTopic vsTopic, List<TopicTournament> tournamentList);
+
+    @Mapping(target = "topic", expression = "java(toVsTopicDto(vsTopic))")
+    @Mapping(target = "tournamentList", expression = "java(toTournamentDtoListFromTournamentEntityList(tournamentList))")
+    VsTopicDto.VsTopicDetailWithTournamentsResponse toVsTopicDetailWithTournaments(
+            VsTopic vsTopic, List<TopicTournament> tournamentList
+    );
 
 }


### PR DESCRIPTION
### 📌 이슈
> #163

### ✅ 작업내용
- 토너먼트 정보를 포함한 대결주제 상세정보 조회 API 의 반환 값 중 [대결주제 정보]에 해당하는 topic 필드가 null 로 반환되는 이슈 확인
- 다수의 필드가 파라미터로 존재 할 경우 mapStruct 에서는 각 대상을 어떻게 매핑할지 자동으로 설정하지 못하는 이슈가 있음
- 다수의 필드가 존재하는 경우에는  각 필드를 어떤 target 으로 mapping 할지 명시해주면 해결이 가능
- 메서드의 반환타입은 ( target field ) 는 문제가 없으나 변환 할 대상 ( source ) 필드는 대상을 이해할 수 없다는 경고를 IDE 가 표시하는 이슈가 있었음
- 해당 이슈는 빌드 및 처리과정에는 문제가 없지만, 정상적이진 않은 것으로 판단
- IDE 의 경고 해제와 실제 처리에 문제가 없도록 expression 을 사용하여 java 형식의 메서드를 직접 매핑하는 식으로 IDE 의 경고를 피했음