### PR TITLE
:bug: 최초 수행 날짜가 비어있는 경우로 조건식 수정 #168

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/statistics/entity/TopicStatistics.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/statistics/entity/TopicStatistics.java
@@ -71,7 +71,7 @@ public class TopicStatistics extends Timestamp {
 
         LocalDateTime now = LocalDateTime.now();
 
-        if(this.firstPlayedAt != null) {
+        if(this.firstPlayedAt == null) {
             this.firstPlayedAt = now;
         }
 


### PR DESCRIPTION
### 📌 이슈
> #168 

### ✅ 작업내용
- 기존의 최초 수행 날짜가 비어있는 경우만 갱신하도록 조건식을 수정
