### PR TITLE
엔트리 대결 완료 후 이벤트 비동기로 전환 #186

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/statistics/service/impl/EntryStatisticsService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/statistics/service/impl/EntryStatisticsService.java
@@ -9,7 +9,10 @@ import com.buck.vsplay.domain.vstopic.entity.TopicEntry;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +28,8 @@ public class EntryStatisticsService implements IEntryStatisticsService {
         createEntryStatistics(entryCreateEvent.getTopicEntryList());
     }
 
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @EventListener
     public void handleEntryMatchCompleteEvent(EntryEvent.MatchCompleteEvent entryMatchCompleteEvent){
         recordEntryMatchStats(entryMatchCompleteEvent.getEntryMatch());


### PR DESCRIPTION
### 📌 이슈
> #186

### ✅ 작업내용
- 매치 종료 이벤트 처리를 비동기로 전환

