### PR TITLE
:recycle: 토너먼트 정보와 함께 대결주제 상세 조회를 LEFT JOIN 으로 수정 #316

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/repository/VsTopicRepository.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/repository/VsTopicRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface VsTopicRepository extends JpaRepository<VsTopic, Long>, JpaSpecificationExecutor<VsTopic> {
 
-    @Query("SELECT vt FROM VsTopic vt JOIN FETCH vt.tournaments WHERE vt.id = :topicId")
+    @Query("SELECT vt FROM VsTopic vt LEFT JOIN FETCH vt.tournaments WHERE vt.id = :topicId")
     VsTopic findWithTournamentsByTopicId(@Param("topicId") Long topicId);
 
     VsTopic findWithTournamentsByShortCode(String shortCode);


### PR DESCRIPTION
### 📌 이슈
>#316

### ✅ 작업내용
- 토너먼트 정보와 함께 대결주제 상세 조회를 LEFT JOIN 으로 수정
