### PR TITLE
[대진표 조회] 현재 진행하는 대진의 토너먼트 정보 추가 반환 #344

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/dto/EntryMatchDto.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/dto/EntryMatchDto.java
@@ -16,6 +16,7 @@ public class EntryMatchDto {
     @Data
     public static class EntryMatchResponse{
         Long matchId;
+        String currentTournament;
         EntryMatch entryMatch = new EntryMatch();
     }
 

--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/MatchService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/MatchService.java
@@ -18,6 +18,7 @@ import com.buck.vsplay.domain.vstopic.mapper.TopicEntryMapper;
 import com.buck.vsplay.domain.vstopic.repository.*;
 import com.buck.vsplay.domain.vstopic.service.IMatchService;
 import com.buck.vsplay.global.constants.PlayStatus;
+import com.buck.vsplay.global.constants.TournamentStage;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -88,6 +89,7 @@ import java.util.*;
         EntryMatch entryMatchWithEntries = entryMatchRepository.findWithEntriesById(entryMatch.getId());
 
         entryMatchResponse.setMatchId(entryMatchWithEntries.getId());
+        entryMatchResponse.setCurrentTournament(TournamentStage.findStageNameByStage(topicPlayRecord.getCurrentTournamentStage()));
         entryMatchResponse.getEntryMatch()
                 .setEntryA(
                         topicEntryMapper.toEntryDtoFromEntity(


### PR DESCRIPTION
### 📌 이슈
> #344

### ✅ 작업내용
- 대진표 조회 결과 반환 시 현재 토너먼트 라운드 추가
