### PR TITLE
[대결 주제 통계] 통계 조회 시 가장 인기있는 엔트리 Null 처리 #374

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/statistics/service/impl/TopicStatisticsService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/statistics/service/impl/TopicStatisticsService.java
@@ -94,10 +94,12 @@ public class TopicStatisticsService implements ITopicStatisticsService {
         VsTopicDto.VsTopic vsTopic = vsTopicMapper.toVsTopicDtoFromEntity(topicStatisticsEntity.getVsTopic());
 
         EntryDto.Entry mostPopularEntry = topicStatistics.getMostPopularEntry();
-        boolean isMediaTypeYoutube = MediaType.YOUTUBE == mostPopularEntry.getMediaType();
+        if( mostPopularEntry != null ) {
+            boolean isMediaTypeYoutube = MediaType.YOUTUBE == mostPopularEntry.getMediaType();
 
-        if( !isMediaTypeYoutube ){ // 유튜브인 경우 signedUrl 변환 없음
-            mostPopularEntry.setMediaUrl(s3Util.getUploadedObjectUrl(mostPopularEntry.getMediaUrl()));
+            if( !isMediaTypeYoutube ){ // 유튜브인 경우 signedUrl 변환 없음
+                mostPopularEntry.setMediaUrl(s3Util.getUploadedObjectUrl(mostPopularEntry.getMediaUrl()));
+            }
         }
 
         return TopicStatisticsDto.TopicStatisticsResponse.builder()


### PR DESCRIPTION
### 📌 이슈
> ex) #이슈번호

### ✅ 작업내용
- 가장 인기있는 엔트리가 비어있는 경우 처리하지 않도록 조건 추가
