### PR TITLE
[대결주제 상세정보 조회] 대결주제 상세정보 조회 API 공개범위&소유 검사 로직 추가 #414

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/VsTopicService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/VsTopicService.java
@@ -118,7 +118,7 @@ public class VsTopicService implements IVsTopicService {
 
     @Override
     public VsTopicDto.VsTopicDetailWithTournamentsResponse getVsTopicDetailWithTournaments(Long topicId) {
-
+        Member existMember = authUserService.getAuthUser();
         VsTopicDto.VsTopicDetailWithTournamentsResponse topicDetailWithTournamentsResponse = new VsTopicDto.VsTopicDetailWithTournamentsResponse();
 
         VsTopic vsTopic = vsTopicRepository.findWithTournamentsByTopicId(topicId);
@@ -127,8 +127,13 @@ public class VsTopicService implements IVsTopicService {
             throw new VsTopicException(VsTopicExceptionCode.TOPIC_NOT_FOUND);
         }
 
-        if ( !isPublicTopic(vsTopic.getVisibility())) {
-            throw new VsTopicException(VsTopicExceptionCode.TOPIC_NOT_PUBLIC);
+        if(!isPublicTopic((vsTopic.getVisibility()))){
+            if( existMember == null) {
+                throw new VsTopicException(VsTopicExceptionCode.TOPIC_NOT_PUBLIC);
+            }
+            if(!vsTopic.getMember().getId().equals(existMember.getId())){
+                throw new VsTopicException(VsTopicExceptionCode.TOPIC_CREATOR_ONLY);
+            }
         }
 
         topicDetailWithTournamentsResponse.setTopic(vsTopicMapper.toVsTopicDtoFromEntityWithThumbnail(vsTopic));


### PR DESCRIPTION
### 📌 이슈
> #414

### ✅ 작업내용
- 대결주제 상세정보 조회 API는 어플리케이션 전반에 걸쳐 사용되며, 일부 페이지에서는 소유권의 확인이 필요함
- 이에 [수정을 위한 대결주제 상세정보 조회 API 추가](https://github.com/douchman/vsplay/issues/412) 에서 소유권 확인을 함께 진행하는 API 를 추가함
- 추가 검토해본 결과 API를 분리하지 않아도, 기존의 API에 공개범위가 아닌 경우 소유권을 추가로 검사하는 로직을 추가하면 해당 API를 각 페이지 별 의도에 맞게 사용이 가능하다고 판단

- 대결주제 상세정보 조회 비즈니스 소유권 검사 로직 추가
