### PR TITLE
🚀 25-06-12 dev -> main 병합 : 환경변수 (LOG_PATH) 를 CI 환경에서 사용가능한 경로로 변경 후 배포 재시도

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,9 +39,6 @@ jobs:
         echo "GPT_API_KEY=${{secrets.GPT_API_KEY}}" >> $GITHUB_ENV
         echo "LOG_PATH=${{secrets.LOG_PATH}}" >> $GITHUB_ENV
 
-    - name: Create log path directory
-      run: mkdir -p $LOG_PATH
-
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
       with:


### PR DESCRIPTION
### 📌 이슈
- #509

### ✅ 작업내용
- 워크플로우에 디렉토리 생성 job 을 추가하는건 [ 빌드 시 file appender 관련 오류] 의 해결책은 아니였음
- CI 환경에서 LOG_PATH 참조 시 권한 및 디렉토리 생성 관련 이슈로 판단되어 , CI 환경에서 참조 가능한 경로 ( 프로젝트 내부경로 ) 로 환경변수 (LOG_PATH) 를 변경 후 배포 재시도
