### PR TITLE
[토너먼트 조회] 불필요한 Update 발생 제거 #525

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/VsTopicService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/VsTopicService.java
@@ -132,11 +132,11 @@ public class VsTopicService implements IVsTopicService {
 
         TopicAccessGuard.validateTopicAccess(vsTopic, authUser.orElse(null));
 
-        vsTopic.setTournaments(tournamentRepository.findByVsTopicIdAndActiveTrue(vsTopic.getId()));
+        List<TopicTournament> topicTournaments = tournamentRepository.findByVsTopicIdAndActiveTrue(vsTopic.getId());
         topicDetailWithTournamentsResponse.setTopic(vsTopicMapper.toVsTopicDtoFromEntityWithModeration(vsTopic));
 
-        if ( vsTopic.getTournaments() != null && !vsTopic.getTournaments().isEmpty() ) {
-            for (TopicTournament tournament : vsTopic.getTournaments()) {
+        if ( topicTournaments != null && !topicTournaments.isEmpty() ) {
+            for (TopicTournament tournament : topicTournaments) {
                 topicDetailWithTournamentsResponse.getTournamentList()
                         .add(tournamentMapper.toTournamentDtoFromEntityWithoutId(tournament));
             }


### PR DESCRIPTION
### 📌 이슈
> #525

### ✅ 작업내용
- 엔티티에 직접 토너먼트 조회를 할당하지 않고 분리하여 처리
