### PR TITLE
[GPT API] GPT 호출 로그 저장 시 초과 이슈 해결 #543

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/global/util/gpt/entity/GptUsageLog.java
+++ b/vsplay/src/main/java/com/buck/vsplay/global/util/gpt/entity/GptUsageLog.java
@@ -52,6 +52,7 @@ public class GptUsageLog extends Timestamp {
     @Comment("응답 소요 시간")
     private Long responseTimeMills;
 
+    @Lob
     @Column(name = "input_preview")
     @Comment("입력 데이터")
     private String inputPreview;


### PR DESCRIPTION
### 📌 이슈
> #543

### ✅ 작업내용
- 입력데이터 컬럼 저장 크기 조정