### PR TITLE
🚀 [배포] 25-07-25 dev -> main 병합 - 빌드 오류 해결을 위한 jdk 버전 변경 후 배포

### DIFF
--- a/vsplay/Dockerfile
+++ b/vsplay/Dockerfile
@@ -1,5 +1,4 @@
-# 베이스 이미지 선택 (Java 17 사용 예시)
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 
 # 작업 디렉토리 설정
 WORKDIR /app/vsplay-api


### PR DESCRIPTION
### 📌 이슈
- #624


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker 이미지 기반을 `openjdk:17-jdk-slim`에서 `eclipse-temurin:17-jdk`로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->