### PR TITLE
[토너먼트] 토너먼트 조회 시 정렬 추가 #670

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/repository/TournamentRepository.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/repository/TournamentRepository.java
@@ -13,7 +13,7 @@ public interface TournamentRepository extends JpaRepository<TopicTournament, Lon
     @Query("SELECT tt FROM TopicTournament tt WHERE tt.vsTopic.id = :topicId AND tt.tournamentStage = :tournamentStage")
     TopicTournament findByTopicIdAndTournamentStage(@Param("topicId") Long topicId, @Param("tournamentStage") Integer tournamentStage);
 
-    List<TopicTournament> findByVsTopicIdAndActiveTrue(Long topicId);
+    List<TopicTournament> findByVsTopicIdAndActiveTrueOrderByTournamentStageAsc(Long topicId);
 
     List<TopicTournament> findByVsTopicId(Long topicId);
 

--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/VsTopicService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/VsTopicService.java
@@ -116,7 +116,7 @@ public class VsTopicService implements IVsTopicService {
         TopicAccessGuard.validateTopicAccess(vsTopic, cachedMemberDtoOpt.orElse(null));
 
         List<VsTopicDto.Tournament> tournamentList = new ArrayList<>();
-        List<TopicTournament> topicTournaments = tournamentRepository.findByVsTopicIdAndActiveTrue(vsTopic.getId());
+        List<TopicTournament> topicTournaments = tournamentRepository.findByVsTopicIdAndActiveTrueOrderByTournamentStageAsc(vsTopic.getId());
 
         if ( topicTournaments != null && !topicTournaments.isEmpty() ) {
             for (TopicTournament tournament : topicTournaments) {


### PR DESCRIPTION
### 📌 이슈
> #670

### ✅ 작업내용
- 토너먼트 리스트 조회 시 오름차순 정렬 적용
