### PR TITLE
🚀 [배포] 토너먼트 정렬 조회 업데이트

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/repository/TournamentRepository.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/repository/TournamentRepository.java
@@ -13,7 +13,7 @@ public interface TournamentRepository extends JpaRepository<TopicTournament, Lon
     @Query("SELECT tt FROM TopicTournament tt WHERE tt.vsTopic.id = :topicId AND tt.tournamentStage = :tournamentStage")
     TopicTournament findByTopicIdAndTournamentStage(@Param("topicId") Long topicId, @Param("tournamentStage") Integer tournamentStage);
 
-    List<TopicTournament> findByVsTopicIdAndActiveTrue(Long topicId);
+    List<TopicTournament> findByVsTopicIdAndActiveTrueOrderByTournamentStageAsc(Long topicId);
 
     List<TopicTournament> findByVsTopicId(Long topicId);
 

--- a/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/VsTopicService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/vstopic/service/impl/VsTopicService.java
@@ -116,7 +116,7 @@ public class VsTopicService implements IVsTopicService {
         TopicAccessGuard.validateTopicAccess(vsTopic, cachedMemberDtoOpt.orElse(null));
 
         List<VsTopicDto.Tournament> tournamentList = new ArrayList<>();
-        List<TopicTournament> topicTournaments = tournamentRepository.findByVsTopicIdAndActiveTrue(vsTopic.getId());
+        List<TopicTournament> topicTournaments = tournamentRepository.findByVsTopicIdAndActiveTrueOrderByTournamentStageAsc(vsTopic.getId());
 
         if ( topicTournaments != null && !topicTournaments.isEmpty() ) {
             for (TopicTournament tournament : topicTournaments) {


### PR DESCRIPTION
### 📌 이슈
- #670


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 주제(Topic) 상세 화면의 활성 토너먼트 목록이 이제 토너먼트 단계 기준으로 오름차순 정렬되어 일관되게 표시됩니다.
  - 이전에는 정렬이 보장되지 않아 표시 순서가 불규칙할 수 있었으나, 이제 예선부터 결승까지 자연스러운 진행 순서로 확인할 수 있습니다.
  - 필터링 조건이나 기능 자체의 동작 변경은 없으며, 표시 순서만 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->