### PR TITLE
[엔트리 조회] 캐싱 추가 #673

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/entry/dto/EntryDto.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/entry/dto/EntryDto.java
@@ -14,6 +14,8 @@ public class EntryDto {
     @Getter
     @Setter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class Entry{
         private Long id;
         private String entryName;

--- a/vsplay/src/main/java/com/buck/vsplay/domain/entry/mapper/TopicEntryMapper.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/entry/mapper/TopicEntryMapper.java
@@ -3,6 +3,7 @@ package com.buck.vsplay.domain.entry.mapper;
 
 import com.buck.vsplay.domain.entry.dto.EntryDto;
 import com.buck.vsplay.domain.entry.entiity.TopicEntry;
+import com.buck.vsplay.global.constants.MediaType;
 import com.buck.vsplay.global.util.aws.s3.S3Util;
 import org.mapstruct.*;
 
@@ -15,7 +16,22 @@ public interface TopicEntryMapper {
     @Mapping(target = "thumbnail", expression = "java(s3Util.getUploadedObjectUrl(topicEntry.getThumbnail()))")
     EntryDto.Entry toEntryDtoFromEntity(TopicEntry topicEntry, S3Util s3Util);
 
+
+    @Mapping(target = "mediaUrl", expression = "java(resolveMediaUrl(topicEntry, s3Util))")
+    @Mapping(target = "thumbnail", expression = "java(s3Util.getUploadedObjectUrl(topicEntry.getThumbnail()))")
+    EntryDto.Entry toEntryDtoFromEntryEntity(TopicEntry topicEntry, S3Util s3Util);
+
+
+
     @Mapping(target = "thumbnail", expression = "java(s3Util.getUploadedObjectUrl(topicEntry.getThumbnail()))")
     EntryDto.Entry toEntryDtoFromEntityWithoutSignedMediaUrl(TopicEntry topicEntry, S3Util s3Util);
 
+
+    default String resolveMediaUrl(TopicEntry topicEntry, S3Util s3Util) {
+        if(topicEntry.getMediaType() == MediaType.YOUTUBE){
+            return topicEntry.getMediaUrl();
+        }
+
+        return s3Util.getUploadedObjectUrl(topicEntry.getMediaUrl());
+    }
 }

--- a/vsplay/src/main/java/com/buck/vsplay/domain/entry/service/impl/EntryCache.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/entry/service/impl/EntryCache.java
@@ -1,0 +1,39 @@
+package com.buck.vsplay.domain.entry.service.impl;
+
+import com.buck.vsplay.domain.entry.dto.EntryDto;
+import com.buck.vsplay.global.redis.util.RedisKeyFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class EntryCache implements IEntryCache {
+
+    private static final Duration TTL = Duration.ofMinutes(30); // 만료시간 30m
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<EntryDto.Entry> getCachedEntries(Long topicId) {
+        String cacheKey = RedisKeyFactory.topicEntries(topicId);
+        return (List<EntryDto.Entry>)redisTemplate.opsForValue().get(cacheKey);
+    }
+
+    @Override
+    public void putEntries(Long topicId, List<EntryDto.Entry> entries) {
+        redisTemplate.opsForValue().set(
+                RedisKeyFactory.topicEntries(topicId),
+                entries,
+                TTL);
+    }
+
+    @Override
+    public void evictEntries(Long topicId) {
+        redisTemplate.delete(RedisKeyFactory.topicEntries(topicId));
+    }
+}

--- a/vsplay/src/main/java/com/buck/vsplay/domain/entry/service/impl/EntryService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/entry/service/impl/EntryService.java
@@ -14,7 +14,6 @@ import com.buck.vsplay.domain.vstopic.service.finder.TopicFinder;
 import com.buck.vsplay.domain.entry.service.handler.EntryUpdateHandler;
 import com.buck.vsplay.domain.entry.service.support.EntryTextExtractor;
 import com.buck.vsplay.domain.entry.service.support.TournamentHandler;
-import com.buck.vsplay.global.constants.MediaType;
 import com.buck.vsplay.global.constants.ModerationStatus;
 import com.buck.vsplay.global.security.service.impl.AuthUserService;
 import com.buck.vsplay.global.util.aws.s3.S3Util;
@@ -45,30 +44,23 @@ public class EntryService implements IEntryService {
     private final TopicFinder topicFinder;
     private final EntryRequestChecker entryRequestChecker;
     private final EntryTextExtractor entryTextExtractor;
+    private final IEntryCache entryCache;
 
     @Override
     public EntryDto.EntryList getEntriesByTopicId(Long topicId) {
 
         topicFinder.validateTopicExists(topicId);
 
-        List<EntryDto.Entry> entryList = new ArrayList<>();
-        List<TopicEntry> createdEntries = entryRepository.findByTopicIdAndDeletedFalse(topicId);
-
-        if( createdEntries != null && !createdEntries.isEmpty()){
-            for (TopicEntry createdEntry : createdEntries) {
-
-                boolean isYoutube = MediaType.YOUTUBE == createdEntry.getMediaType();
-
-                entryList.add(
-                        isYoutube ?
-                                topicEntryMapper.toEntryDtoFromEntityWithoutSignedMediaUrl(createdEntry, s3Util)
-                                : topicEntryMapper.toEntryDtoFromEntity(createdEntry, s3Util)
-                );
-            }
-        }
-
         return EntryDto.EntryList.builder()
-                .entries(entryList)
+                .entries(Optional.ofNullable(entryCache.getCachedEntries(topicId))
+                        .orElseGet(() -> {
+                            List<EntryDto.Entry> entryList = new ArrayList<>(entryRepository.findByTopicIdAndDeletedFalse(topicId)
+                                    .stream()
+                                    .map( entry -> topicEntryMapper.toEntryDtoFromEntryEntity(entry, s3Util))
+                                    .toList());
+                            entryCache.putEntries(topicId, entryList);
+                            return entryList;
+                        }))
                 .build();
     }
 
@@ -89,6 +81,9 @@ public class EntryService implements IEntryService {
         }
 
         entryRepository.saveAll(topicEntries);
+
+        entryCache.evictEntries(topicId); // 캐시 삭제
+
         applicationEventPublisher.publishEvent(new EntryEvent.CreateEvent(topicEntries));
         tournamentHandler.handleTournament(vsTopic);
     }
@@ -128,6 +123,8 @@ public class EntryService implements IEntryService {
                         }
                     });
         }
+
+        entryCache.evictEntries(topicId); // 캐시 삭제
         tournamentHandler.handleTournament(vsTopic); // 갱신된 엔트리를 기준으로 토너먼트 재구성
     }
 }

--- a/vsplay/src/main/java/com/buck/vsplay/domain/entry/service/impl/IEntryCache.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/entry/service/impl/IEntryCache.java
@@ -1,0 +1,11 @@
+package com.buck.vsplay.domain.entry.service.impl;
+
+import com.buck.vsplay.domain.entry.dto.EntryDto;
+
+import java.util.List;
+
+public interface IEntryCache {
+    List<EntryDto.Entry> getCachedEntries(Long topicId);
+    void putEntries(Long topicId, List<EntryDto.Entry> entries);
+    void evictEntries(Long topicId);
+}

--- a/vsplay/src/main/java/com/buck/vsplay/global/redis/util/RedisKeyFactory.java
+++ b/vsplay/src/main/java/com/buck/vsplay/global/redis/util/RedisKeyFactory.java
@@ -8,4 +8,5 @@ public class RedisKeyFactory {
     public static String user(Long memberId){
         return RedisKeyPrefix.USER + memberId;
     }
+    public static String topicEntries(Long topicId) { return RedisKeyPrefix.TOPIC_ENTRIES + topicId; }
 }

--- a/vsplay/src/main/java/com/buck/vsplay/global/redis/util/RedisKeyPrefix.java
+++ b/vsplay/src/main/java/com/buck/vsplay/global/redis/util/RedisKeyPrefix.java
@@ -8,4 +8,5 @@ public final class RedisKeyPrefix {
     public static final String USER = "user_";
     public static final String TOPIC = "topic_";
     public static final String ENTRY = "entry_";
+    public static final String TOPIC_ENTRIES = "topic_entries_";
 }


### PR DESCRIPTION
### 📌 이슈
> #673

### ✅ 작업내용
- 엔트리 조회 캐싱 용 Cache Key 설정 추가
- 캐싱 비즈니스 구현
- entity to dto 매핑 메서드 추가
