### PR TITLE
[엔트리 조회] EntryMapper 리팩터링 #674

### DIFF
--- a/vsplay/src/main/java/com/buck/vsplay/domain/entry/mapper/TopicEntryMapper.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/entry/mapper/TopicEntryMapper.java
@@ -12,20 +12,9 @@ public interface TopicEntryMapper {
 
     TopicEntry toEntityFromCreatedEntryDto(EntryDto.CreateEntry topicEntry);
 
-    @Mapping(target = "mediaUrl", expression = "java(s3Util.getUploadedObjectUrl(topicEntry.getMediaUrl()))")
-    @Mapping(target = "thumbnail", expression = "java(s3Util.getUploadedObjectUrl(topicEntry.getThumbnail()))")
-    EntryDto.Entry toEntryDtoFromEntity(TopicEntry topicEntry, S3Util s3Util);
-
-
     @Mapping(target = "mediaUrl", expression = "java(resolveMediaUrl(topicEntry, s3Util))")
     @Mapping(target = "thumbnail", expression = "java(s3Util.getUploadedObjectUrl(topicEntry.getThumbnail()))")
     EntryDto.Entry toEntryDtoFromEntryEntity(TopicEntry topicEntry, S3Util s3Util);
-
-
-
-    @Mapping(target = "thumbnail", expression = "java(s3Util.getUploadedObjectUrl(topicEntry.getThumbnail()))")
-    EntryDto.Entry toEntryDtoFromEntityWithoutSignedMediaUrl(TopicEntry topicEntry, S3Util s3Util);
-
 
     default String resolveMediaUrl(TopicEntry topicEntry, S3Util s3Util) {
         if(topicEntry.getMediaType() == MediaType.YOUTUBE){

--- a/vsplay/src/main/java/com/buck/vsplay/domain/match/service/impl/MatchService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/match/service/impl/MatchService.java
@@ -10,7 +10,6 @@ import com.buck.vsplay.domain.member.dto.CachedMemberDto;
 import com.buck.vsplay.domain.statistics.event.EntryEvent;
 import com.buck.vsplay.domain.statistics.event.TopicEvent;
 import com.buck.vsplay.domain.statistics.event.TournamentEvent;
-import com.buck.vsplay.domain.entry.dto.EntryDto;
 import com.buck.vsplay.domain.match.dto.EntryMatchDto;
 import com.buck.vsplay.domain.match.dto.TopicPlayRecordDto;
 import com.buck.vsplay.domain.vstopic.entity.*;
@@ -26,7 +25,6 @@ import com.buck.vsplay.domain.entry.mapper.TopicEntryMapper;
 import com.buck.vsplay.domain.vstopic.moderation.TopicAccessGuard;
 import com.buck.vsplay.domain.vstopic.repository.*;
 import com.buck.vsplay.domain.match.service.IMatchService;
-import com.buck.vsplay.global.constants.MediaType;
 import com.buck.vsplay.global.constants.PlayStatus;
 import com.buck.vsplay.global.constants.TournamentStage;
 import com.buck.vsplay.global.constants.Visibility;
@@ -119,8 +117,8 @@ import java.util.*;
             EntryMatch entryMatchWithEntries = entryMatchRepository.findWithEntriesById(entryMatch.getId());
             entryMatchResponse.setMatchId(entryMatchWithEntries.getId());
             entryMatchResponse.setEntryMatch(EntryMatchDto.EntryMatch.builder()
-                    .entryA(mappingTopicEntryToEntryDto(entryMatchWithEntries.getEntryA()))
-                    .entryB(mappingTopicEntryToEntryDto(entryMatchWithEntries.getEntryB()))
+                    .entryA(topicEntryMapper.toEntryDtoFromEntryEntity(entryMatchWithEntries.getEntryA(), s3Util))
+                    .entryB(topicEntryMapper.toEntryDtoFromEntryEntity(entryMatchWithEntries.getEntryB(), s3Util))
                     .build());
         } else { // 완료 된 대결
             EntryMatch completedEntryMatch = entryMatchRepository.findByTopicPlayRecordIdAndTournamentRound(topicPlayRecord.getId(), topicPlayRecord.getCurrentTournamentStage());
@@ -128,8 +126,8 @@ import java.util.*;
             entryMatchResponse.setWinnerEntryId(completedEntryMatch.getWinnerEntry().getId());
 
             entryMatchResponse.setEntryMatch(EntryMatchDto.EntryMatch.builder()
-                    .entryA(mappingTopicEntryToEntryDto(completedEntryMatch.getEntryA()))
-                    .entryB(mappingTopicEntryToEntryDto(completedEntryMatch.getEntryB()))
+                    .entryA(topicEntryMapper.toEntryDtoFromEntryEntity(completedEntryMatch.getEntryA(), s3Util))
+                    .entryB(topicEntryMapper.toEntryDtoFromEntryEntity(completedEntryMatch.getEntryB(), s3Util))
                     .build());
         }
 
@@ -282,14 +280,6 @@ import java.util.*;
         EntryMatch entryMatch = entryMatchRepository.findByPlayRecordIdAndTournamentRoundOrderBySeqAsc(topicPlayRecord.getId(),currentTournamentStage);
 
         return entryMatch.getStatus().equals(PlayStatus.COMPLETED);
-    }
-
-    private EntryDto.Entry mappingTopicEntryToEntryDto(TopicEntry topicEntry){
-        if(MediaType.YOUTUBE == topicEntry.getMediaType()){
-            return topicEntryMapper.toEntryDtoFromEntityWithoutSignedMediaUrl(topicEntry, s3Util);
-        } else {
-            return topicEntryMapper.toEntryDtoFromEntity(topicEntry, s3Util);
-        }
     }
 
     private boolean isPasswordTopic(Visibility visibility){

--- a/vsplay/src/main/java/com/buck/vsplay/domain/statistics/service/impl/EntryStatisticsService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/statistics/service/impl/EntryStatisticsService.java
@@ -7,7 +7,6 @@ import com.buck.vsplay.domain.statistics.event.EntryEvent;
 import com.buck.vsplay.domain.statistics.mapper.EntryStatisticsMapper;
 import com.buck.vsplay.domain.statistics.repository.EntryStatisticsRepository;
 import com.buck.vsplay.domain.statistics.service.IEntryStatisticsService;
-import com.buck.vsplay.domain.entry.dto.EntryDto;
 import com.buck.vsplay.domain.match.entity.EntryMatch;
 import com.buck.vsplay.domain.entry.entiity.TopicEntry;
 import com.buck.vsplay.domain.vstopic.entity.VsTopic;
@@ -20,7 +19,6 @@ import com.buck.vsplay.domain.vstopic.moderation.TopicAccessGuard;
 import com.buck.vsplay.domain.vstopic.repository.VsTopicRepository;
 import com.buck.vsplay.global.batch.entity.BatchJobExecution;
 import com.buck.vsplay.global.batch.repository.BatchJobExecutionRepository;
-import com.buck.vsplay.global.constants.MediaType;
 import com.buck.vsplay.global.dto.Pagination;
 import com.buck.vsplay.global.security.service.impl.AuthUserService;
 import com.buck.vsplay.global.util.DateTimeUtil;
@@ -140,14 +138,9 @@ public class EntryStatisticsService implements IEntryStatisticsService {
         }
 
         for (EntryStatistics entryStatistic : entryStatistics) {
-            boolean isYouTube = MediaType.YOUTUBE == entryStatistic.getTopicEntry().getMediaType();
             entriesStatistics.add(
                     EntryStatisticsDto.EntryStatWithEntryInfo.builder()
-                            .entry(
-                                    isYouTube ?
-                                            topicEntryMapper.toEntryDtoFromEntityWithoutSignedMediaUrl(entryStatistic.getTopicEntry(), s3Util)
-                                            :topicEntryMapper.toEntryDtoFromEntity(entryStatistic.getTopicEntry(), s3Util)
-                            )
+                            .entry(topicEntryMapper.toEntryDtoFromEntryEntity(entryStatistic.getTopicEntry(), s3Util))
                             .statistics(entryStatisticsMapper.toEntryStatisticsDtoFromEntity(entryStatistic))
                             .build()
             );
@@ -189,15 +182,9 @@ public class EntryStatisticsService implements IEntryStatisticsService {
                 () -> new EntryException(EntryExceptionCode.ENTRY_NOT_FOUND)
         );
 
-        boolean isYoutubeMediaType = MediaType.YOUTUBE == entryStatistics.getTopicEntry().getMediaType();
-        EntryDto.Entry entry = isYoutubeMediaType?
-                        topicEntryMapper.toEntryDtoFromEntityWithoutSignedMediaUrl(entryStatistics.getTopicEntry(), s3Util)
-                        : topicEntryMapper.toEntryDtoFromEntity(entryStatistics.getTopicEntry(), s3Util);
-        EntryStatisticsDto.EntryStatistics statistics = entryStatisticsMapper.toEntryStatisticsDtoFromEntity(entryStatistics);
-
         return EntryStatisticsDto.SingleEntryStatsResponse.builder()
-                .entry(entry)
-                .statistics(statistics)
+                .entry(topicEntryMapper.toEntryDtoFromEntryEntity(entryStatistics.getTopicEntry(), s3Util))
+                .statistics(entryStatisticsMapper.toEntryStatisticsDtoFromEntity(entryStatistics))
                 .build();
     }
 }

--- a/vsplay/src/main/java/com/buck/vsplay/domain/statistics/service/impl/EntryVersusStatisticsService.java
+++ b/vsplay/src/main/java/com/buck/vsplay/domain/statistics/service/impl/EntryVersusStatisticsService.java
@@ -17,7 +17,6 @@ import com.buck.vsplay.domain.entry.mapper.TopicEntryMapper;
 import com.buck.vsplay.domain.vstopic.moderation.TopicAccessGuard;
 import com.buck.vsplay.domain.entry.repository.EntryRepository;
 import com.buck.vsplay.domain.vstopic.repository.VsTopicRepository;
-import com.buck.vsplay.global.constants.MediaType;
 import com.buck.vsplay.global.security.service.impl.AuthUserService;
 import com.buck.vsplay.global.util.aws.s3.S3Util;
 import lombok.RequiredArgsConstructor;
@@ -86,13 +85,10 @@ public class EntryVersusStatisticsService implements IEntryVersusStatisticsServi
 
         if ( entryVersusStatistics != null && !entryVersusStatistics.isEmpty()){
             for (EntryVersusStatistics entryVersusStatistic : entryVersusStatistics) {
-                boolean isYoutubeMediaType = MediaType.YOUTUBE == entryVersusStatistic.getOpponentEntry().getMediaType();
                 opponentEntryInfoWithMatchRecords.add(
                         EntryVersusStatisticsDto.OpponentEntryInfoWithMatchRecord.builder()
                                 .opponentEntry(
-                                        isYoutubeMediaType ?
-                                            topicEntryMapper.toEntryDtoFromEntityWithoutSignedMediaUrl(entryVersusStatistic.getOpponentEntry(), s3Util)
-                                            : topicEntryMapper.toEntryDtoFromEntity(entryVersusStatistic.getOpponentEntry(), s3Util))
+                                        topicEntryMapper.toEntryDtoFromEntryEntity(entryVersusStatistic.getOpponentEntry(), s3Util))
                                 .matchRecord(EntryVersusStatisticsDto.MatchRecord.builder()
                                         .totalMatches(entryVersusStatistic.getTotalMatches())
                                         .wins(entryVersusStatistic.getWins())


### PR DESCRIPTION
### 📌 이슈
> #674

### ✅ 작업내용
- Entity to Dto 매핑 메서드 리팩터링
   - 미디어 타입 분기 처리를 Mapper 에 default 메서드로 추가
   - 기존 매핑 메서드 호출부 전면 교체
   - 미사용 코드 제거
 
